### PR TITLE
fixed message header handling, added timeout verbose messages, simpli…

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/mini-maxit/worker/internal/config"
-	"github.com/mini-maxit/worker/logger"
+	"github.com/mini-maxit/worker/internal/logger"
 	"github.com/mini-maxit/worker/worker"
 )
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,7 +20,8 @@ services:
       - FILESTORAGE_HOST=file-storage
       - FILESTORAGE_PORT=8888
   file-storage:
-    image: maxit/file-storage
+    image: file-storage
+    pull_policy: never
     container_name: file-storage
     ports:
       - "8888:8888"

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -25,53 +25,40 @@ type Executor interface {
 	String() string
 }
 
-type ExecutorStatusCode int
-
-const (
-	ErInternalError ExecutorStatusCode = iota
-	ErSuccess
-	ErSignalRecieved
-	ErNetworkProhibited
-	ErJailed
-	ErTimeout
-	ErMemoryLimitExceeded
-)
-
 const CompileErrorFileName = "compile-err.err"
 
 const BaseChrootDir = "../tmp/chroot"
 
-type ExecutionResult struct {
-	StatusCode ExecutorStatusCode
-	Message    string
-}
+const (
+	Success             = 0
+	InternalError       = 1
+	TimeLimitExceeded   = 124
+	MemoryLimitExceeded = 137
+)
 
-func (ec ExecutorStatusCode) String() string {
-	switch ec {
-	case ErInternalError:
-		return "InternalError"
-	case ErSuccess:
+func ExitCodeToString(exitCode int) string {
+	switch exitCode {
+	case Success:
 		return "Success"
-	case ErSignalRecieved:
-		return "SignalRecieved"
-	case ErNetworkProhibited:
-		return "NetworkProhibited"
-	case ErJailed:
-		return "Jailed"
-	case ErTimeout:
-		return "Timeout"
-	case ErMemoryLimitExceeded:
+	case TimeLimitExceeded:
+		return "TimeLimitExceeded"
+	case MemoryLimitExceeded:
 		return "MemoryLimitExceeded"
 	default:
 		return "Unknown"
 	}
 }
 
+type ExecutionResult struct {
+	ExitCode int
+	Message  string
+}
+
 func (er *ExecutionResult) String() string {
 	var out bytes.Buffer
 
 	out.WriteString("ExecutionResult{")
-	out.WriteString(fmt.Sprintf("StatusCode: %d, ", er.StatusCode))
+	out.WriteString(fmt.Sprintf("ExitCode: %d, ", er.ExitCode))
 	out.WriteString("}")
 
 	return out.String()
@@ -88,6 +75,7 @@ func restrictCommand(executablePath string, timeLimit int) *exec.Cmd {
 		"chroot",
 		BaseChrootDir,
 		"timeout",
+		"--verbose",
 		timeLimitSecondsString,
 		executeCommand,
 	}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -6,7 +6,8 @@ import (
 	"os/exec"
 	"strconv"
 
-	"github.com/mini-maxit/worker/logger"
+	"github.com/mini-maxit/worker/internal/constants"
+	"github.com/mini-maxit/worker/internal/logger"
 )
 
 type CommandConfig struct {
@@ -25,25 +26,16 @@ type Executor interface {
 	String() string
 }
 
-const CompileErrorFileName = "compile-err.err"
-
-const BaseChrootDir = "../tmp/chroot"
-
-const (
-	Success             = 0
-	InternalError       = 1
-	TimeLimitExceeded   = 124
-	MemoryLimitExceeded = 137
-)
-
 func ExitCodeToString(exitCode int) string {
 	switch exitCode {
-	case Success:
+	case constants.ExitCodeSuccess:
 		return "Success"
-	case TimeLimitExceeded:
+	case constants.ExitCodeTimeLimitExceeded:
 		return "TimeLimitExceeded"
-	case MemoryLimitExceeded:
+	case constants.ExitCodeMemoryLimitExceeded:
 		return "MemoryLimitExceeded"
+	case constants.ExitCodeInternalError:
+		return "InternalError"
 	default:
 		return "Unknown"
 	}
@@ -73,7 +65,7 @@ func restrictCommand(executablePath string, timeLimit int) *exec.Cmd {
 
 	args := []string{
 		"chroot",
-		BaseChrootDir,
+		constants.BaseChrootDir,
 		"timeout",
 		"--verbose",
 		timeLimitSecondsString,

--- a/executor/executor_config.go
+++ b/executor/executor_config.go
@@ -8,10 +8,6 @@ type ExecutorConfig struct {
 	// Placeholder, maybe verifier will be stored here
 }
 
-const (
-	ExitCodeTimeout = 124
-)
-
 // Creates config with default base values
 func NewDefaultExecutorConfig() *ExecutorConfig {
 	return &ExecutorConfig{}

--- a/internal/config/worker_config.go
+++ b/internal/config/worker_config.go
@@ -7,16 +7,8 @@ import (
 	"strconv"
 
 	"github.com/joho/godotenv"
-	"github.com/mini-maxit/worker/logger"
-)
-
-const (
-	DefailtRabbitmqHost     = "localhost"
-	DefaultRabbitmqUser     = "guest"
-	DefaultRabbitmqPassword = "guest"
-	DefaultRabbitmqPort     = "5672"
-	DefaultFileStorageHost  = "file-storage"
-	DefaultFilesStoragePort = "8888"
+	"github.com/mini-maxit/worker/internal/constants"
+	"github.com/mini-maxit/worker/internal/logger"
 )
 
 type Config struct {
@@ -44,13 +36,13 @@ func NewConfig() *Config {
 
 	rabbitmqHost := os.Getenv("RABBITMQ_HOST")
 	if rabbitmqHost == "" {
-		rabbitmqHost = DefailtRabbitmqHost
-		logger.Warnf("RABBITMQ_HOST is not set, using default value %s", DefailtRabbitmqHost)
+		rabbitmqHost = constants.DefailtRabbitmqHost
+		logger.Warnf("RABBITMQ_HOST is not set, using default value %s", constants.DefailtRabbitmqHost)
 	}
 	rabbitmqPortStr := os.Getenv("RABBITMQ_PORT")
 	if rabbitmqPortStr == "" {
-		rabbitmqPortStr = DefaultRabbitmqPort
-		logger.Warnf("RABBITMQ_PORT is not set, using default value %s", DefaultRabbitmqPort)
+		rabbitmqPortStr = constants.DefaultRabbitmqPort
+		logger.Warnf("RABBITMQ_PORT is not set, using default value %s", constants.DefaultRabbitmqPort)
 	}
 	rabbitmqPort, err := strconv.ParseUint(rabbitmqPortStr, 10, 16)
 	if err != nil {
@@ -58,24 +50,24 @@ func NewConfig() *Config {
 	}
 	rabbitmqUser := os.Getenv("RABBITMQ_USER")
 	if rabbitmqUser == "" {
-		rabbitmqUser = DefaultRabbitmqUser
-		logger.Warnf("RABBITMQ_USER is not set, using default value %s", DefaultRabbitmqUser)
+		rabbitmqUser = constants.DefaultRabbitmqUser
+		logger.Warnf("RABBITMQ_USER is not set, using default value %s", constants.DefaultRabbitmqUser)
 	}
 	rabbitmqPassword := os.Getenv("RABBITMQ_PASSWORD")
 	if rabbitmqPassword == "" {
-		rabbitmqPassword = DefaultRabbitmqPassword
-		logger.Warnf("RABBITMQ_PASSWORD is not set, using default value %s", DefaultRabbitmqPassword)
+		rabbitmqPassword = constants.DefaultRabbitmqPassword
+		logger.Warnf("RABBITMQ_PASSWORD is not set, using default value %s", constants.DefaultRabbitmqPassword)
 	}
 
 	fileStorageHost := os.Getenv("FILESTORAGE_HOST")
 	if fileStorageHost == "" {
-		fileStorageHost = DefaultFileStorageHost
-		logger.Warnf("FILESTORAGE_HOST is not set, using default value %s", DefaultFileStorageHost)
+		fileStorageHost = constants.DefaultFileStorageHost
+		logger.Warnf("FILESTORAGE_HOST is not set, using default value %s", constants.DefaultFileStorageHost)
 	}
 	fileStoragePortStr := os.Getenv("FILESTORAGE_PORT")
 	if fileStoragePortStr == "" {
-		fileStoragePortStr = DefaultFilesStoragePort
-		logger.Warnf("FILESTORAGE_PORT is not set, using default value %s", DefaultFilesStoragePort)
+		fileStoragePortStr = constants.DefaultFilesStoragePort
+		logger.Warnf("FILESTORAGE_PORT is not set, using default value %s", constants.DefaultFilesStoragePort)
 	}
 	fileStoragePort, err := strconv.ParseUint(fileStoragePortStr, 10, 16)
 	if err != nil {

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,0 +1,58 @@
+package constants
+
+// SolutionResult messages
+const (
+	SolutionMessageSuccess             = "solution executed successfully"
+	SolutionMessageRuntimeError        = "solution execution failed"
+	SolutionMessageInvalidLanguageType = "invalid language type supplied"
+	SolutionMessageTimeout             = "some test cases failed due to time limit exceeded"
+	SolutionMessageMemoryLimitExceeded = "some test cases failed due to memory limit exceeded"
+)
+
+// TestResult messages
+const (
+	TestMessageTimeLimitExceeded   = "time limit exceeded"
+	TestMessageMemoryLimitExceeded = "memory limit exceeded"
+)
+
+// Worker specific constants
+const (
+	SolutionFileBaseName = "solution"
+	InputDirName         = "inputs"
+	OutputDirName        = "outputs"
+	MaxRetries           = 2
+)
+
+// Language types
+const (
+	CPP = "cpp"
+)
+
+// Language versions
+const (
+	CPP_11 = "11"
+	CPP_14 = "14"
+	CPP_17 = "17"
+	CPP_20 = "20"
+)
+
+// Exit codes
+const (
+	ExitCodeSuccess             = 0
+	ExitCodeInternalError       = 1
+	ExitCodeTimeLimitExceeded   = 124
+	ExitCodeMemoryLimitExceeded = 137
+)
+
+// Configuratioin constants
+const (
+	DefailtRabbitmqHost     = "localhost"
+	DefaultRabbitmqUser     = "guest"
+	DefaultRabbitmqPassword = "guest"
+	DefaultRabbitmqPort     = "5672"
+	DefaultFileStorageHost  = "file-storage"
+	DefaultFilesStoragePort = "8888"
+	DefaultLogPath          = "./internal/logger/logs/log.txt"
+	CompileErrorFileName    = "compile-err.err"
+	BaseChrootDir           = "../tmp/chroot"
+)

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,11 @@
+package errors
+
+import "errors"
+
+// Error messages
+var (
+	ErrUnknownFileType       = errors.New("unknown file type")
+	ErrInvalidLanguageType   = errors.New("invalid language type")
+	ErrInvalidVersion        = errors.New("invalid version supplied")
+	ErrFailedToStoreSolution = errors.New("failed to store the solution result")
+)

--- a/internal/logger/logger_config.go
+++ b/internal/logger/logger_config.go
@@ -4,12 +4,11 @@ import (
 	"os"
 	"sync"
 
+	"github.com/mini-maxit/worker/internal/constants"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
-
-const logPath = "./logger/logs/worker/log.txt"
 
 const (
 	timeKey   = "time"
@@ -29,7 +28,7 @@ func InitializeLogger() {
 		currentLevel = zap.NewAtomicLevelAt(zap.InfoLevel) // Default to InfoLevel
 
 		fileSync := zapcore.AddSync(&lumberjack.Logger{
-			Filename: logPath,
+			Filename: constants.DefaultLogPath,
 			MaxAge:   1,
 			Compress: true,
 		})

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -5,6 +5,6 @@ docker compose up --build -d
 
 sleep 15
 
-docker compose exec go_app go test -count=1 -timeout 30s -v ./tests
+docker compose exec go_app go test -count=1 -timeout 100s -v ./tests
 
 docker compose down

--- a/solution/solution.go
+++ b/solution/solution.go
@@ -23,6 +23,8 @@ const (
 	InternalError
 	// Means there was an error while initializing the executor
 	InitializationError
+	// Means there was an runtime error while executing the solution
+	RuntimeError
 )
 
 func (ss SolutionStatus) String() string {
@@ -37,6 +39,8 @@ func (ss SolutionStatus) String() string {
 		return "CompilationError"
 	case InitializationError:
 		return "InitializationError"
+	case RuntimeError:
+		return "RuntimeError"
 	default:
 		return "Unknown"
 	}

--- a/tests/worker_test.go
+++ b/tests/worker_test.go
@@ -12,7 +12,8 @@ import (
 	"testing"
 
 	"github.com/mini-maxit/worker/internal/config"
-	"github.com/mini-maxit/worker/logger"
+	"github.com/mini-maxit/worker/internal/logger"
+	"github.com/mini-maxit/worker/solution"
 	"github.com/mini-maxit/worker/worker"
 	amqp "github.com/rabbitmq/amqp091-go"
 	"go.uber.org/zap/zapcore"
@@ -257,7 +258,7 @@ func deleteTask(taskID string) error {
 
 func generateExpectedResponseMessage(msgType MessageType) string {
 	var expectedResponse strings.Builder
-	var statusCode string
+	var statusCode solution.SolutionStatus
 	var message string
 	var code string
 	var sucess bool
@@ -265,20 +266,20 @@ func generateExpectedResponseMessage(msgType MessageType) string {
 
 	switch msgType {
 	case Success:
-		code = "Success"
-		statusCode = "1"
+		code = solution.Success.String()
+		statusCode = solution.Success
 		message = "solution executed successfully"
 		sucess = true
 		testResult = `"TestResults":[{"Passed":true,"ErrorMessage":"","Order":1}]`
 	case FailedTimeLimitExceeded:
-		code = "Timeout"
-		message = "The command timed out"
-		statusCode = "3"
+		code = solution.RuntimeError.String()
+		message = "some test cases failed due to time limit exceeded"
+		statusCode = solution.RuntimeError
 		sucess = false
-		testResult = `"TestResults":null`
+		testResult = `"TestResults":[{"Passed":false,"ErrorMessage":"time limit exceeded","Order":1}]`
 	case CompilationError:
-		code = "CompilationError"
-		statusCode = "2"
+		code = solution.CompilationError.String()
+		statusCode = solution.CompilationError
 		message = "exit status 1"
 		sucess = false
 		testResult = `"TestResults":null`
@@ -286,7 +287,7 @@ func generateExpectedResponseMessage(msgType MessageType) string {
 		code = "Unknown"
 	}
 
-	message = fmt.Sprintf(`{"message_id":"adsa","result":{"OutputDir":"user-output","Success":%t,"StatusCode":%s,"Code":"%s","Message":"%s",%s}}`, sucess, statusCode, code, message, testResult)
+	message = fmt.Sprintf(`{"message_id":"adsa","result":{"OutputDir":"user-output","Success":%t,"StatusCode":%d,"Code":"%s","Message":"%s",%s}}`, sucess, statusCode, code, message, testResult)
 
 	expectedResponse.WriteString(message)
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,16 +3,14 @@ package utils
 import (
 	"archive/tar"
 	"compress/gzip"
-	"errors"
 	"io"
 	"log"
 	"os"
 	"path"
 	"path/filepath"
-)
 
-var errUnknownFileType = errors.New("unknown file type")
-var errUnknownLanguageType = errors.New("unknown language type")
+	"github.com/mini-maxit/worker/internal/errors"
+)
 
 // Attemts to close the file, and panics if something goes wrong
 func CloseFile(file *os.File) {
@@ -126,7 +124,7 @@ func ExtractTarGz(filePath string, baseFilePath string) error {
 			}
 
 		default:
-			return errUnknownFileType
+			return errors.ErrUnknownFileType
 		}
 	}
 	return nil
@@ -210,7 +208,7 @@ func GetSolutionFileNameWithExtension(SolutionFileBaseName string, languageType 
 	case "CPP":
 		return SolutionFileBaseName + ".cpp", nil
 	default:
-		return "", errUnknownLanguageType
+		return "", errors.ErrInvalidLanguageType
 	}
 }
 

--- a/worker/rabbitmq.go
+++ b/worker/rabbitmq.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/mini-maxit/worker/internal/config"
-	"github.com/mini-maxit/worker/logger"
+	"github.com/mini-maxit/worker/internal/logger"
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 

--- a/worker/solution.go
+++ b/worker/solution.go
@@ -8,7 +8,7 @@ import (
 	"os"
 
 	"github.com/google/uuid"
-	"github.com/mini-maxit/worker/logger"
+	"github.com/mini-maxit/worker/internal/logger"
 	"github.com/mini-maxit/worker/solution"
 	"github.com/mini-maxit/worker/utils"
 	"go.uber.org/zap"


### PR DESCRIPTION
[fix to issue #15 and more]
This pull request includes several changes to the `executor` package, focusing on improving error handling and standardizing exit codes. The key changes involve updating the `CppExecutor` to use exit codes instead of status codes, modifying the `Executor` interface and related constants, and updating the `Runner` to handle the new exit codes appropriately.

### Changes to error handling and exit codes:

* [`executor/cpp_executor.go`](diffhunk://#diff-1f8cc2a204896feeeb3509480d8ee8c679e8356c5c7b1d54b30cfd607f27bb94L45-R42): Replaced `StatusCode` with `ExitCode` in multiple error handling scenarios to standardize the error reporting mechanism. [[1]](diffhunk://#diff-1f8cc2a204896feeeb3509480d8ee8c679e8356c5c7b1d54b30cfd607f27bb94L45-R42) [[2]](diffhunk://#diff-1f8cc2a204896feeeb3509480d8ee8c679e8356c5c7b1d54b30cfd607f27bb94L60-R57) [[3]](diffhunk://#diff-1f8cc2a204896feeeb3509480d8ee8c679e8356c5c7b1d54b30cfd607f27bb94L74-R71) [[4]](diffhunk://#diff-1f8cc2a204896feeeb3509480d8ee8c679e8356c5c7b1d54b30cfd607f27bb94L83-R84) [[5]](diffhunk://#diff-1f8cc2a204896feeeb3509480d8ee8c679e8356c5c7b1d54b30cfd607f27bb94L103-R100) [[6]](diffhunk://#diff-1f8cc2a204896feeeb3509480d8ee8c679e8356c5c7b1d54b30cfd607f27bb94L116-R124)
* [`executor/executor.go`](diffhunk://#diff-4c9a4c1e9a402d07a0a78f4db9f766d23f1ff57ceda1e75c4e83b579488ad301L28-R61): Removed `ExecutorStatusCode` and replaced it with integer-based exit codes. Added `ExitCodeToString` function to convert exit codes to strings.
* [`executor/executor_config.go`](diffhunk://#diff-5596b25c539642421d194536459e31f6c89342ece62cbd5e36e239a33e811baeL11-L14): Removed the `ExitCodeTimeout` constant as it is now defined in the `executor` package.

### Updates to `Runner` and `Solution`:

* [`solution/runner.go`](diffhunk://#diff-cbf16078f5ce9a63b5c09307c046e0f2464ac5ae7864e79c6065186250d3d12cR138-R139): Updated the `RunSolution` method to handle new exit codes and set appropriate solution statuses and messages based on the execution results. [[1]](diffhunk://#diff-cbf16078f5ce9a63b5c09307c046e0f2464ac5ae7864e79c6065186250d3d12cR138-R139) [[2]](diffhunk://#diff-cbf16078f5ce9a63b5c09307c046e0f2464ac5ae7864e79c6065186250d3d12cL150-R153) [[3]](diffhunk://#diff-cbf16078f5ce9a63b5c09307c046e0f2464ac5ae7864e79c6065186250d3d12cR170-R209)
* [`solution/solution.go`](diffhunk://#diff-7a0b8596167f921043fefe0f0563e337b28af95f9f363debce78db44d53a0463R26-R27): Added `RuntimeError` to the `SolutionStatus` enum to capture runtime errors during solution execution. [[1]](diffhunk://#diff-7a0b8596167f921043fefe0f0563e337b28af95f9f363debce78db44d53a0463R26-R27) [[2]](diffhunk://#diff-7a0b8596167f921043fefe0f0563e337b28af95f9f363debce78db44d53a0463R42-R43)

### Other changes:

* [`executor/cpp_executor.go`](diffhunk://#diff-1f8cc2a204896feeeb3509480d8ee8c679e8356c5c7b1d54b30cfd607f27bb94L8): Removed the unnecessary import of `strings`.
* [`executor/executor.go`](diffhunk://#diff-4c9a4c1e9a402d07a0a78f4db9f766d23f1ff57ceda1e75c4e83b579488ad301R78): Added the `--verbose` flag to the `timeout` command in the `restrictCommand` function for better debugging.
* [`worker/worker.go`](diffhunk://#diff-a497cf86b016d9c95cc8d6a4d99bf1bea36490b188fad3414822222234b654aeL293-R306): Improved the retry mechanism in the `getNewMsg` function by properly handling the retry count and updating the message headers.