### PR TITLE
feat: add execution time tracking to test results

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,13 @@ Upon successful execution of the task, the worker sends a message to the specifi
     "TestResults": [
       {
         "Passed": false,
+        "ExecutionTime": 0.000000,
         "ErrorMessage": "Difference at line 1:\nOutput:   Hello, World!\nExpected: Hello World!\n\n",
         "Order": 1
       },
       {
         "Passed": true,
+        "ExecutionTime": 0.000000,
         "ErrorMessage": "",
         "Order": 2
       }

--- a/internal/solution/solution.go
+++ b/internal/solution/solution.go
@@ -44,7 +44,8 @@ type SolutionResult struct {
 	TestResults []TestResult   // test results in case of error or success
 }
 type TestResult struct {
-	Passed       bool   // Whether the test passed or failed
-	ErrorMessage string // Error message in case of failure (if any)
-	Order        int    // Order to input output pair for ex 1 mean in1.in and out1.out was used
+	Passed        bool    // Whether the test passed or failed
+	ExecutionTime float64 // Execution time of the test
+	ErrorMessage  string  // Error message in case of failure (if any)
+	Order         int     // Order to input output pair for ex 1 mean in1.in and out1.out was used
 }

--- a/tests/worker_test.go
+++ b/tests/worker_test.go
@@ -296,6 +296,8 @@ func TestProcessTask(t *testing.T) {
 					t.Fatalf("Failed to parse response JSON: %s", err)
 				}
 
+				t.Logf("Response: %+v", actualResponse)
+
 				if !validateResponse(tt.testType, actualResponse) {
 					err = os.RemoveAll(taskDir)
 					if err != nil {


### PR DESCRIPTION
This pull request introduces several changes to the codebase, primarily focusing on adding execution time tracking for test results and improving logging for debugging purposes. The most important changes include modifications to the `runnerService` to measure and record execution times, updates to the `TestResult` struct to include execution time, and enhancements to the test logging.

### Execution Time Tracking:

* [`internal/services/runnerService.go`](diffhunk://#diff-6cc41a1e34bd38a0c720458a998d1a238103a9a74a8d7e78ff1cb225e4b41615R135-R139): Added execution time measurement for each test case in the `RunSolution` function, recording the start and end times of the execution and calculating the duration. [[1]](diffhunk://#diff-6cc41a1e34bd38a0c720458a998d1a238103a9a74a8d7e78ff1cb225e4b41615R135-R139) [[2]](diffhunk://#diff-6cc41a1e34bd38a0c720458a998d1a238103a9a74a8d7e78ff1cb225e4b41615R161-R169) [[3]](diffhunk://#diff-6cc41a1e34bd38a0c720458a998d1a238103a9a74a8d7e78ff1cb225e4b41615R180) [[4]](diffhunk://#diff-6cc41a1e34bd38a0c720458a998d1a238103a9a74a8d7e78ff1cb225e4b41615R191)
* [`internal/solution/solution.go`](diffhunk://#diff-1a347d001383931c204c3a01135f2aaf0adecc496edf93cc76983be653c7bb23R48): Updated the `TestResult` struct to include a new field `ExecutionTime` to store the execution duration of each test.

### Logging Improvements:

* [`tests/worker_test.go`](diffhunk://#diff-a64c6544c3c4c39f6a7f16dab8f9b769a0deb05b9502b7165eac40c0bfd95cd1R299-R300): Enhanced the `TestProcessTask` function to log the response for better debugging and validation of test results.

### Additional Changes:

* [`internal/services/runnerService.go`](diffhunk://#diff-6cc41a1e34bd38a0c720458a998d1a238103a9a74a8d7e78ff1cb225e4b41615R7): Added the `time` package import to support execution time tracking.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R84-R90): Updated sample test results to include the `ExecutionTime` field for better documentation and clarity.